### PR TITLE
Distribution improvements

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "extends": "./node_modules/builder-radium-component/config/babel/.babelrc"
+  "extends": "builder-radium-component/config/babel/.babelrc",
+  "plugins": [
+    "./plugins/lib/babel-plugin-inline-worker"
+  ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "0.10"
   - "0.12"
   - "4.2"
   - "5.9"

--- a/config/webpack.lib.config.js
+++ b/config/webpack.lib.config.js
@@ -1,0 +1,38 @@
+var path = require("path");
+var webpack = require("webpack");
+
+var ROOT = process.cwd();
+var SRC = path.join(ROOT, "src");
+
+module.exports = {
+  cache: true,
+  context: SRC,
+  output: {
+    path: path.join(ROOT, "lib"),
+    libraryTarget: "var"
+  },
+  resolve: {
+    extensions: ["", ".js", ".jsx"]
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        include: [SRC],
+        loader: "babel-loader"
+      }
+    ]
+  },
+  plugins: [
+    new webpack.optimize.DedupePlugin(),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
+      }
+    }),
+    new webpack.DefinePlugin({
+      "process.env.NODE_ENV": JSON.stringify("production")
+    }),
+    new webpack.SourceMapDevToolPlugin({filename: "[file].map"})
+  ]
+};

--- a/interfaces/autolayout.js
+++ b/interfaces/autolayout.js
@@ -58,3 +58,66 @@ declare module "autolayout" {
     addConstraints(constraints: Array<Constraint>): View;
   }
 }
+
+declare module "autolayout/lib/kiwi/View" {
+  declare type Relation =
+    | "equ"
+    | "leq"
+    | "geq"
+
+  declare type Priority =
+    | 1000
+    | 750
+    | 250
+
+  declare type Constraint = {
+    view1?: ?string,
+    attr1?: ?string,
+    relation?: ?Relation,
+    view2?: ?string,
+    attr2?: ?string,
+    constant?: ?number,
+    multiplier?: ?number,
+    priority?: ?Priority
+  };
+
+  declare class SubView {
+    name: string;
+    left: number;
+    right: number;
+    width: number;
+    height: number;
+    intrinsicWidth: number;
+    intrinsicHeight: number;
+    top: number;
+    bottom: number;
+    centerX: number;
+    centerY: number;
+    zIndex: number;
+    type: string;
+
+    getValue(attr: string): number;
+  }
+
+  declare class View {
+    width: number;
+    height: number;
+    fittingWidth: number;
+    fittingHeight: number;
+    subViews: { [key: string]: SubView };
+
+    constructor(options: ?{
+      width?: number,
+      height?: number,
+      spacing?: number | Array<number>,
+      constraints?: Array<Constraint>
+    }): void;
+
+    setSize(width: number, height: number): View;
+    setSpacing(spacing: number | Array<number>): View;
+    addConstraint(constraint: Constraint): View;
+    addConstraints(constraints: Array<Constraint>): View;
+  }
+
+  declare function exports(): View
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "autolayout": "FormidableLabs/autolayout.js#7a28278",
+    "babel-plugin-webpack-loaders": "^0.4.0",
     "builder": "^2.8.0",
     "builder-radium-component": "^2.0.0",
     "coveralls": "^2.11.8",
@@ -31,7 +32,6 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0",
-    "babel-plugin-webpack-loaders": "^0.4.0",
     "babel-polyfill": "^6.6.1",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -18,19 +18,20 @@
     "version": "builder run npm:version",
     "test": "builder run npm:test",
     "lint": "builder concurrent lint-server lint-client lint-client-test flow",
-    "flow": "node -e \"process.exit(process.platform === 'win32' ? 0 : 1)\" || flow check"
+    "flow": "node -e \"process.exit(process.platform === 'win32' ? 0 : 1)\" || flow check",
+    "build-lib": "builder run clean-lib && babel plugins/src -d plugins/lib --copy-files && babel src -d lib --copy-files"
   },
   "dependencies": {
-    "autolayout": "^0.5.3",
+    "autolayout": "FormidableLabs/autolayout.js#7a28278",
     "builder": "^2.8.0",
     "builder-radium-component": "^2.0.0",
     "coveralls": "^2.11.8",
     "react": "^0.14.7",
-    "react-dom": "^0.14.7",
-    "worker-loader": "^0.7.0"
+    "react-dom": "^0.14.7"
   },
   "devDependencies": {
-    "babel-eslint": "^6.0.0-beta.6",
+    "babel-eslint": "^6.0.0",
+    "babel-plugin-webpack-loaders": "^0.4.0",
     "babel-polyfill": "^6.6.1",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.6.0",

--- a/plugins/.babelrc
+++ b/plugins/.babelrc
@@ -1,0 +1,3 @@
+{
+  "extends": "builder-radium-component/config/babel/.babelrc"
+}

--- a/plugins/src/babel-plugin-inline-worker.js
+++ b/plugins/src/babel-plugin-inline-worker.js
@@ -1,0 +1,41 @@
+/* eslint-env node */
+import path from "path";
+import runWebPackSync from "babel-plugin-webpack-loaders/lib/runWebPackSync";
+import config from "../../config/webpack.lib.config";
+
+// Behold! The Babel-Webpack Frankenstein monster!
+// I am not proud of this.
+export default ({ types: t }) => {
+  return {
+    visitor: {
+      StringLiteral(nodePath, state) {
+        if (
+          nodePath.node &&
+          nodePath.node.value &&
+          nodePath.node.value.indexOf("babel-inline-worker!") === 0
+        ) {
+          const [, fileName] = nodePath.node.value.split("!");
+          const resolvedPath = path.resolve(
+            process.cwd(),
+            path.dirname(state.file.opts.filename),
+            fileName
+          );
+          const fileContents = runWebPackSync({
+            path: resolvedPath,
+            configPath: path.resolve(
+              process.cwd(),
+              "config/webpack.lib.config"
+            ),
+            config,
+            verbose: false
+          });
+          nodePath.replaceWith(
+            t.stringLiteral(
+              new Buffer(fileContents).toString("base64")
+            )
+          );
+        }
+      }
+    }
+  };
+};

--- a/src/engine.js
+++ b/src/engine.js
@@ -2,7 +2,7 @@
 /* eslint-env worker */
 import type { SubView } from "autolayout";
 import type ConstraintBuilder from "./constraint-builder";
-import { View } from "autolayout";
+import View from "autolayout/lib/kiwi/View";
 
 export type Layout = {
   width: number,

--- a/test/client/spec/components/layout-client.spec.jsx
+++ b/test/client/spec/components/layout-client.spec.jsx
@@ -7,6 +7,10 @@ class MockWorker {
   terminate() {}
 }
 
+const mockWorkerFactory = () => {
+  return new MockWorker();
+};
+
 class MockProxy {
   worker: Worker;
 
@@ -23,14 +27,14 @@ class MockProxy {
 
 describe("Layout client", () => {
   it("should initialize a views dict and the correct # of workers", () => {
-    const client = new LayoutClient(4, MockProxy, MockWorker);
+    const client = new LayoutClient(4, mockWorkerFactory, MockProxy);
     expect(client).to.have.property("views");
     const workers = client.workers;
     expect(workers.length).to.equal(4);
   });
 
   it("should register a view and cycle to the next worker", () => {
-    const client = new LayoutClient(4, MockProxy, MockWorker);
+    const client = new LayoutClient(4, mockWorkerFactory, MockProxy);
     const size = {
       width: 10,
       height: 5
@@ -45,7 +49,7 @@ describe("Layout client", () => {
   });
 
   it("should deregister a view", () => {
-    const client = new LayoutClient(4, MockProxy, MockWorker);
+    const client = new LayoutClient(4, mockWorkerFactory, MockProxy);
     const size = {
       width: 10,
       height: 5
@@ -57,7 +61,7 @@ describe("Layout client", () => {
   });
 
   it("should terminate all workers", () => {
-    const client = new LayoutClient(4, MockProxy, MockWorker);
+    const client = new LayoutClient(4, mockWorkerFactory, MockProxy);
     const size = {
       width: 10,
       height: 5
@@ -71,4 +75,3 @@ describe("Layout client", () => {
     expect(client.workers.length).to.equal(0);
   });
 });
-


### PR DESCRIPTION
Going to merge this immediately, but would like some eyes on it for the sake of future improvement.
- A Frankenstein's monster combining a Babel plugin with Webpack now allows for inline workers in both `lib/` and `dist/`. Don't laugh at it _too_ hard :laughing: 
- Using our updated fork of `autolayout.js`, we can not only exclude the giant VFL parser from our bundle, but also easily switch between constraint solvers (`kiwi` or `cassowary.js`). Bundle size is now in the realm of ~16KB gzipped.

@boygirl @divmain et al
