### PR TITLE
Fix bugs when using multiple superviews.

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -33,13 +33,14 @@ export type WorkerArgs = {
 // message to the main thread with the method
 // name and result.
 const postCallback = (
+  viewName: string,
   callbackName: string,
   method: (args: WorkerArgs) => bool | Layout
 ) => {
   return (args: WorkerArgs) => {
     const result = method(args);
     postMessage({
-      method: callbackName, result
+      viewName, method: callbackName, result
     });
   };
 };
@@ -156,11 +157,13 @@ export default class Engine {
         intrinsicWidth,
         intrinsicHeight
       } = item;
-      this.addIntrinsics({
-        viewName, subviewName, intrinsics: {
-          intrinsicWidth, intrinsicHeight
-        }
-      });
+      if (subviewName && intrinsicWidth && intrinsicHeight) {
+        this.addIntrinsics({
+          viewName, subviewName, intrinsics: {
+            intrinsicWidth, intrinsicHeight
+          }
+        });
+      }
     });
 
     return this.subviews({ viewName });
@@ -204,6 +207,6 @@ onmessage = ({ data: message }) => {
   const { method, args } = message;
   // $FlowIssue: doesn't support dynamic lookup yet
   if (engine[method]) {
-    postCallback(method, engine[method].bind(engine))(args);
+    postCallback(args.viewName, method, engine[method].bind(engine))(args);
   }
 };

--- a/src/superview.js
+++ b/src/superview.js
@@ -1,10 +1,12 @@
 // @flow
+/* eslint-disable new-cap */
 import type { SubView } from "autolayout";
 import type { Element } from "react";
 import type LayoutClient from "./layout-client";
 
 import { Component, PropTypes, createElement } from "react";
 import extractLayoutProps from "./extract-layout-props";
+import UUID from "./uuid";
 
 type Props = {
   name: string,
@@ -24,7 +26,7 @@ type Context = {
   client: LayoutClient
 };
 
-export default class Superview extends Component {
+export default UUID(class Superview extends Component {
   props: Props;
   state: State;
 
@@ -87,4 +89,4 @@ export default class Superview extends Component {
     };
     return createElement(container, newProps, children);
   }
-}
+});

--- a/src/uuid.js
+++ b/src/uuid.js
@@ -1,0 +1,25 @@
+// @flow
+import type { Element } from "react";
+
+import React, { Component } from "react";
+import uuid from "node-uuid";
+
+type Props = {
+  name: string,
+  children: ?ReactPropTypes.node,
+  style: ?Object
+};
+
+export default (ComposedComponent: ReactClass): ReactClass =>
+class extends Component {
+  uniqueName: string;
+
+  constructor(props: Props) {
+    super(props);
+    this.uniqueName = `${props.name}-${uuid.v4()}`;
+  }
+
+  render(): ?Element {
+    return <ComposedComponent {...this.props} name={this.uniqueName} />;
+  }
+};

--- a/src/worker-proxy.js
+++ b/src/worker-proxy.js
@@ -14,18 +14,19 @@ export default class WorkerProxy {
     this.callbacks = {};
     this.worker.onmessage = ({ data: message }) => {
       const method = message.method || null;
-      if (method) {
-        const cb = this.callbacks[method];
+      const viewName = message.viewName || null;
+      if (method && viewName) {
+        const cb = this.callbacks[method + viewName];
         if (cb) {
           cb(message.result || null);
-          this.callbacks[method] = null;
+          this.callbacks[method + viewName] = null;
         }
       }
     };
   }
 
   run(method: string, args: Object, cb: (result: ?Cloneable) => void) {
-    this.callbacks[method] = cb;
+    this.callbacks[method + args.viewName] = cb;
     this.worker.postMessage({ method, args });
   }
 

--- a/test/client/spec/components/constraint-layout.spec.jsx
+++ b/test/client/spec/components/constraint-layout.spec.jsx
@@ -1,6 +1,6 @@
-/* eslint-disable new-cap*/
+/* eslint-disable new-cap,no-unused-expressions */
 import React from "react";
-import ConstraintLayout, { Superview } from "src";
+import ConstraintLayout, { AutoDOM, constrain, Superview } from "src";
 import { mount } from "enzyme";
 
 describe("ConstraintLayout component", () => {
@@ -19,7 +19,10 @@ describe("ConstraintLayout component", () => {
     expect(client.workers).to.be.an("array");
     expect(client.views).to.be.an("object");
     expect(Object.keys(client.views)).to.have.lengthOf(1);
-    expect(client.views).to.have.property("main");
+    expect(
+      Object.keys(client.views)
+        .every((key) => key.indexOf("main") !== -1)
+    ).to.be.true;
   });
 });
 
@@ -40,5 +43,50 @@ describe("Superview component", () => {
     expect(container.length).to.equal(1);
     expect(container.node.style.width).to.equal("400px");
     expect(container.node.style.height).to.equal("250px");
+  });
+
+  it("should layout subviews correctly when using multiple superviews", () => {
+    const superviews = [0, 1, 2, 3, 4, 5, 6, 7, 8].map((index) => {
+      const superviewName = `main-${index}`;
+      const subviewName = `paragraph-lol-${index}`;
+      return (
+        <Superview
+          key={index}
+          name={superviewName}
+          container="div"
+          width={400}
+          height={250}
+        >
+          <AutoDOM.div
+            name={subviewName}
+            intrinsicWidth={100}
+            intrinsicHeight={100}
+            constraints={[
+              constrain().subview(subviewName).centerX
+                .to.equal.superview.centerX,
+              constrain().subview(subviewName).centerY
+                .to.equal.superview.centerY
+            ]}
+          >
+            <p>I'm a paragraph lol</p>
+          </AutoDOM.div>
+        </Superview>
+      );
+    });
+    const result = mount(
+      <ConstraintLayout>
+        {superviews}
+      </ConstraintLayout>
+    );
+
+    const client = result.node.client;
+    expect(client.workers).to.be.an("array");
+    expect(client.views).to.be.an("object");
+    expect(Object.keys(client.views))
+      .to.have.lengthOf(superviews.length);
+    expect(
+      Object.keys(client.views)
+        .every((key) => key.indexOf("main") !== -1)
+    ).to.be.true;
   });
 });


### PR DESCRIPTION
Superviews now use a UUID so that they don't clobber each other.

More importantly, callbacks in the layout client are now a combination of method name and superview name. This prevents subsequently processed `registerView` callbacks from erasing the previous callbacks.
