### PR TITLE
Remove unnecessary parentheses from `constrain()`

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -77,8 +77,8 @@ class App extends Component {
             intrinsicWidth={300}
             intrinsicHeight={45}
             constraints={[
-              constrain().subview("note").centerX.to.equal.superview.centerX,
-              constrain().subview("note").centerY.to.equal.superview.centerY
+              constrain.subview("note").centerX.to.equal.superview.centerX,
+              constrain.subview("note").centerY.to.equal.superview.centerY
             ]}
           >
             Worst clock ever! Resize the window for full effect.
@@ -89,8 +89,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("12").centerX.to.equal.superview.centerX,
-              constrain().subview("12").top.to.equal.superview.top
+              constrain.subview("12").centerX.to.equal.superview.centerX,
+              constrain.subview("12").top.to.equal.superview.top
             ]}
           >
             12
@@ -101,8 +101,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("1").centerX.to.equal.superview.centerX.times(1 + 1 / 3),
-              constrain().subview("1").centerY.to.equal.superview.height.times(1 / 6)
+              constrain.subview("1").centerX.to.equal.superview.centerX.times(1 + 1 / 3),
+              constrain.subview("1").centerY.to.equal.superview.height.times(1 / 6)
             ]}
           >
             1
@@ -113,8 +113,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("2").centerX.to.equal.superview.centerX.times(1 + 2 / 3),
-              constrain().subview("2").centerY.to.equal.superview.height.times(1 / 3)
+              constrain.subview("2").centerX.to.equal.superview.centerX.times(1 + 2 / 3),
+              constrain.subview("2").centerY.to.equal.superview.height.times(1 / 3)
             ]}
           >
             2
@@ -125,8 +125,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("3").right.to.equal.superview.right,
-              constrain().subview("3").centerY.to.equal.superview.centerY
+              constrain.subview("3").right.to.equal.superview.right,
+              constrain.subview("3").centerY.to.equal.superview.centerY
             ]}
           >
             3
@@ -137,8 +137,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("4").centerX.to.equal.superview.centerX.times(1 + 2 / 3),
-              constrain().subview("4").centerY.to.equal.superview.height.times(2 / 3)
+              constrain.subview("4").centerX.to.equal.superview.centerX.times(1 + 2 / 3),
+              constrain.subview("4").centerY.to.equal.superview.height.times(2 / 3)
             ]}
           >
             4
@@ -149,8 +149,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("5").centerX.to.equal.superview.centerX.times(1 + 1 / 3),
-              constrain().subview("5").centerY.to.equal.superview.height.times(5 / 6)
+              constrain.subview("5").centerX.to.equal.superview.centerX.times(1 + 1 / 3),
+              constrain.subview("5").centerY.to.equal.superview.height.times(5 / 6)
             ]}
           >
             5
@@ -161,8 +161,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("6").bottom.to.equal.superview.bottom,
-              constrain().subview("6").centerX.to.equal.superview.centerX
+              constrain.subview("6").bottom.to.equal.superview.bottom,
+              constrain.subview("6").centerX.to.equal.superview.centerX
             ]}
           >
             6
@@ -173,8 +173,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("7").centerX.to.equal.superview.centerX.times(2 / 3),
-              constrain().subview("7").centerY.to.equal.superview.height.times(5 / 6)
+              constrain.subview("7").centerX.to.equal.superview.centerX.times(2 / 3),
+              constrain.subview("7").centerY.to.equal.superview.height.times(5 / 6)
             ]}
           >
             7
@@ -185,8 +185,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("8").centerX.to.equal.superview.centerX.times(1 / 3),
-              constrain().subview("8").centerY.to.equal.superview.height.times(2 / 3)
+              constrain.subview("8").centerX.to.equal.superview.centerX.times(1 / 3),
+              constrain.subview("8").centerY.to.equal.superview.height.times(2 / 3)
             ]}
           >
             8
@@ -197,8 +197,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("9").centerY.to.equal.superview.centerY,
-              constrain().subview("9").left.to.equal.superview.left
+              constrain.subview("9").centerY.to.equal.superview.centerY,
+              constrain.subview("9").left.to.equal.superview.left
             ]}
           >
             9
@@ -209,8 +209,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("10").centerX.to.equal.superview.centerX.times(2 / 3),
-              constrain().subview("10").centerY.to.equal.superview.height.times(1 / 6)
+              constrain.subview("10").centerX.to.equal.superview.centerX.times(2 / 3),
+              constrain.subview("10").centerY.to.equal.superview.height.times(1 / 6)
             ]}
           >
             10
@@ -221,8 +221,8 @@ class App extends Component {
             intrinsicWidth={50}
             intrinsicHeight={50}
             constraints={[
-              constrain().subview("11").centerX.to.equal.superview.centerX.times(1 / 3),
-              constrain().subview("11").centerY.to.equal.superview.height.times(1 / 3)
+              constrain.subview("11").centerX.to.equal.superview.centerX.times(1 / 3),
+              constrain.subview("11").centerY.to.equal.superview.height.times(1 / 3)
             ]}
           >
             11

--- a/src/constraint-builder.js
+++ b/src/constraint-builder.js
@@ -162,4 +162,4 @@ class ConstraintBuilder {
   }
 }
 
-export default (): ConstraintBuilder => new ConstraintBuilder();
+export default ((): ConstraintBuilder => new ConstraintBuilder())();

--- a/src/superview.js
+++ b/src/superview.js
@@ -5,8 +5,8 @@ import type { Element } from "react";
 import type LayoutClient from "./layout-client";
 
 import { Component, PropTypes, createElement } from "react";
-import extractLayoutProps from "./extract-layout-props";
 import UUID from "./uuid";
+import extractLayoutProps from "./extract-layout-props";
 
 type Props = {
   name: string,
@@ -26,7 +26,7 @@ type Context = {
   client: LayoutClient
 };
 
-export default UUID(class Superview extends Component {
+class Superview extends Component {
   props: Props;
   state: State;
 
@@ -69,6 +69,7 @@ export default UUID(class Superview extends Component {
     if (width === oldWidth && height === oldHeight) {
       return;
     }
+
     this.context.client.run("setSize", {
       viewName, size: { width, height }
     }, (layout) => this.onLayout(layout));
@@ -89,4 +90,6 @@ export default UUID(class Superview extends Component {
     };
     return createElement(container, newProps, children);
   }
-});
+}
+
+export default UUID(Superview);

--- a/test/client/spec/components/constraint-builder.spec.jsx
+++ b/test/client/spec/components/constraint-builder.spec.jsx
@@ -3,7 +3,7 @@ import { constrain } from "src";
 
 describe("Constraint builder", () => {
   it("should create a simple subview -> superview equality", () => {
-    const constraint = constrain().subview("test").width
+    const constraint = constrain.subview("test").width
       .to.equal.superview.width.build();
     expect(constraint).to.have.deep.property("view1", "test");
     expect(constraint).to.have.deep.property("attr1", "width");
@@ -13,7 +13,7 @@ describe("Constraint builder", () => {
   });
 
   it("should create a simple subview -> subview equality", () => {
-    const constraint = constrain().subview("test").width
+    const constraint = constrain.subview("test").width
       .to.equal.subview("otherTest").width.build();
     expect(constraint).to.have.deep.property("view1", "test");
     expect(constraint).to.have.deep.property("attr1", "width");
@@ -23,7 +23,7 @@ describe("Constraint builder", () => {
   });
 
   it("should create a simple subview -> superview inequality", () => {
-    const constraint = constrain().subview("test").height
+    const constraint = constrain.subview("test").height
       .to.be.lessThanOrEqualTo.superview.height.build();
     expect(constraint).to.have.deep.property("view1", "test");
     expect(constraint).to.have.deep.property("attr1", "height");
@@ -33,7 +33,7 @@ describe("Constraint builder", () => {
   });
 
   it("should create a simple subview -> subview inequality", () => {
-    const constraint = constrain().subview("test").height
+    const constraint = constrain.subview("test").height
       .to.be.greaterThanOrEqualTo.subview("otherTest").height.build();
     expect(constraint).to.have.deep.property("view1", "test");
     expect(constraint).to.have.deep.property("attr1", "height");
@@ -50,7 +50,7 @@ describe("Constraint builder", () => {
     ];
 
     for (const attribute of supportedAttributes) {
-      const constraint = constrain().subview("test")[attribute]
+      const constraint = constrain.subview("test")[attribute]
         .to.equal.superview[attribute].build();
 
       expect(constraint).to.have.deep.property("view1", "test");
@@ -62,7 +62,7 @@ describe("Constraint builder", () => {
   });
 
   it("should constrain a subview to a constant", () => {
-    const constraint = constrain().subview("test").left
+    const constraint = constrain.subview("test").left
       .to.equal.constant(10).build();
     expect(constraint).to.have.deep.property("view1", "test");
     expect(constraint).to.have.deep.property("attr1", "left");
@@ -72,7 +72,7 @@ describe("Constraint builder", () => {
   });
 
   it("should constrain a superview to a constant", () => {
-    const constraint = constrain().superview.left
+    const constraint = constrain.superview.left
       .to.equal.constant(20).build();
     expect(constraint).to.have.deep.property("view1", null);
     expect(constraint).to.have.deep.property("attr1", "left");
@@ -82,7 +82,7 @@ describe("Constraint builder", () => {
   });
 
   it("should constrain a subview attribute to a superview attribute plus a constant", () => {
-    const constraint = constrain().subview("test").left
+    const constraint = constrain.subview("test").left
       .to.equal.superview.left.plus(30).build();
     expect(constraint).to.have.deep.property("view1", "test");
     expect(constraint).to.have.deep.property("attr1", "left");
@@ -93,7 +93,7 @@ describe("Constraint builder", () => {
   });
 
   it("should constrain a subview attribute to a superview attribute minus a constant", () => {
-    const constraint = constrain().subview("test").left
+    const constraint = constrain.subview("test").left
       .to.equal.superview.left.minus(30).build();
     expect(constraint).to.have.deep.property("view1", "test");
     expect(constraint).to.have.deep.property("attr1", "left");
@@ -104,7 +104,7 @@ describe("Constraint builder", () => {
   });
 
   it("should constrain a subview attribute to a superview attribute with a multiplier", () => {
-    const constraint = constrain().subview("test").left
+    const constraint = constrain.subview("test").left
       .to.equal.superview.left.times(2).build();
     expect(constraint).to.have.deep.property("view1", "test");
     expect(constraint).to.have.deep.property("attr1", "left");
@@ -115,7 +115,7 @@ describe("Constraint builder", () => {
   });
 
   it("should constrain a subview attribute to a superview attribute with a priority", () => {
-    const constraint = constrain().subview("test").left
+    const constraint = constrain.subview("test").left
       .to.equal.superview.left.withPriority(250).build();
     expect(constraint).to.have.deep.property("view1", "test");
     expect(constraint).to.have.deep.property("attr1", "left");

--- a/test/client/spec/components/constraint-layout.spec.jsx
+++ b/test/client/spec/components/constraint-layout.spec.jsx
@@ -62,9 +62,9 @@ describe("Superview component", () => {
             intrinsicWidth={100}
             intrinsicHeight={100}
             constraints={[
-              constrain().subview(subviewName).centerX
+              constrain.subview(subviewName).centerX
                 .to.equal.superview.centerX,
-              constrain().subview(subviewName).centerY
+              constrain.subview(subviewName).centerY
                 .to.equal.superview.centerY
             ]}
           >

--- a/test/client/spec/components/engine.spec.jsx
+++ b/test/client/spec/components/engine.spec.jsx
@@ -117,7 +117,7 @@ describe("Engine", () => {
         intrinsicWidth={200}
         intrinsicHeight={100}
         constraints={[
-          constrain().subview("testSubview").centerX
+          constrain.subview("testSubview").centerX
             .to.equal.superview.centerX
         ]}
       >
@@ -155,7 +155,7 @@ describe("Engine", () => {
     const subviews = engine.addConstraints({
       viewName: "test",
       constraints: [
-        constrain().subview("testSubview").centerX
+        constrain.subview("testSubview").centerX
           .to.equal.superview.centerX.build()
       ]
     });
@@ -183,7 +183,7 @@ describe("Engine", () => {
     engine.addConstraints({
       viewName: "test",
       constraints: [
-        constrain().subview("testSubview").centerX
+        constrain.subview("testSubview").centerX
           .to.equal.superview.centerX.build()
       ]
     });


### PR DESCRIPTION
Use an IIFE to return an instance of ConstraintBuilder instead of making the API consumer construct it.

This changes `constrain().superview` to `constrain.superview`. It is a breaking change.
