### PR TITLE
Add top-level Superview constraints prop

### DIFF
--- a/demo/app.jsx
+++ b/demo/app.jsx
@@ -70,16 +70,16 @@ class App extends Component {
           style={{
             background: colors.shade1
           }}
+          constraints={[
+            constrain.subview("note").centerX.to.equal.superview.centerX,
+            constrain.subview("note").centerY.to.equal.superview.centerY
+          ]}
         >
           <AutoDOM.p
             name="note"
             style={{...styles.box, fontSize: "16px", border: 0}}
             intrinsicWidth={300}
             intrinsicHeight={45}
-            constraints={[
-              constrain.subview("note").centerX.to.equal.superview.centerX,
-              constrain.subview("note").centerY.to.equal.superview.centerY
-            ]}
           >
             Worst clock ever! Resize the window for full effect.
           </AutoDOM.p>

--- a/src/superview.js
+++ b/src/superview.js
@@ -3,6 +3,7 @@
 import type { SubView } from "autolayout";
 import type { Element } from "react";
 import type LayoutClient from "./layout-client";
+import type ConstraintBuilder from "./constraint-builder";
 
 import { Component, PropTypes, createElement } from "react";
 import UUID from "./uuid";
@@ -10,6 +11,7 @@ import extractLayoutProps from "./extract-layout-props";
 
 type Props = {
   name: string,
+  constraints: ?Array<ConstraintBuilder>,
   container: ReactClass,
   children: ReactPropTypes.node,
   width: number,
@@ -48,13 +50,16 @@ class Superview extends Component {
 
   componentDidMount() {
     const {
-      container, children, name, width, height, spacing
+      constraints, container, children, name, width, height, spacing
     } = this.props;
     const size = { width, height };
     const { client } = this.context;
 
     const element = createElement(container, null, children);
-    const layoutProps = extractLayoutProps(element);
+    const layoutProps = extractLayoutProps(element)
+      .concat(constraints ? {
+        constraints: constraints.map((c) => c.build())
+      } : []);
 
     client.registerView(name, size, spacing, () => {
       client.run("initializeSubviews", {


### PR DESCRIPTION
The new `constraints` prop on `<Superview>` allows adding constraints at the top level instead of at the child level. Useful for Victory integration and for consumer components that expose a `constraints` prop but not necessarily the names of their child subviews.
